### PR TITLE
Update permissions note

### DIFF
--- a/ModeratorInstructions.md
+++ b/ModeratorInstructions.md
@@ -18,7 +18,7 @@ That's it.
 
 ## Permissions
 
-You can add [/u/modlogs](https://www.reddit.com/user/modlogs) as a moderator with no permissions, but if you want to use a custom configuration you'll need to give it the `wiki` permission.
+You can add [/u/modlogs](https://www.reddit.com/user/modlogs) as a moderator with no permissions, but if you want to use a custom configuration you'll need to give it the `wiki` permission. Alternatively, you can allow all users to view the page by enabling wikis in the subreddit's settings. If the subreddit already enables wikis then no special permissions are needed.
 
 ## Configuration
 


### PR DESCRIPTION
The permissions section implies giving u/modlogs the `wiki` permission is required. Another option is to enable the subreddit's wiki pages so all users can view them. For subreddits that already enable wiki pages, granting the bot wiki permissions is not required.